### PR TITLE
fix(#139): OAuth 로그인 시 프로필 설정이 계속 표시되는 문제 수정

### DIFF
--- a/apps/web/src/app/(auth)/signUp/page.tsx
+++ b/apps/web/src/app/(auth)/signUp/page.tsx
@@ -25,9 +25,14 @@ function SignUpContent() {
 
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
-
+ 
       refetchProfile();
-      router.replace('/profile-setup');
+      
+      if (isProfileCompleted === 'true') {
+        router.replace('/main');
+      } else {
+        router.replace('/profile-setup');
+      }
     }
   }, [searchParams, router]);
 

--- a/libs/ui/src/hooks/callback/LoginCallbackClient.tsx
+++ b/libs/ui/src/hooks/callback/LoginCallbackClient.tsx
@@ -41,7 +41,12 @@ export function LoginCallbackClient() {
           localStorage.setItem('refreshToken', refreshToken);
 
           refetchProfile();
-          router.push('/profile-setup');
+          
+          if (isProfileCompleted === 'true') {
+            router.push('/main');
+          } else {
+            router.push('/profile-setup');
+          }
           return;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication flow: After signing up or logging in via OAuth, users with already-completed profiles are now automatically directed to the main app, skipping the profile setup screen. New users continue to be directed to complete profile setup. This streamlines the experience for returning users while maintaining proper account setup for new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->