### PR TITLE
fix: 회의 종료 직후 참여도 조회 지연 처리

### DIFF
--- a/libs/shop/data/src/lib/hooks/meeting/use-get-total-engagement.ts
+++ b/libs/shop/data/src/lib/hooks/meeting/use-get-total-engagement.ts
@@ -4,11 +4,18 @@ import type { TotalEngagementResponse } from './types';
 export const getTotalEngagement = async (
   teamId: string,
   meetingId: string
-): Promise<TotalEngagementResponse> => {
+): Promise<TotalEngagementResponse | { status: 404; data: null }> => {
   try {
     const response = await privateApi.get<TotalEngagementResponse>(
-      `/teams/${teamId}/meetings/${meetingId}/participation`
+      `/teams/${teamId}/meetings/${meetingId}/participation`,
+      {
+        validateStatus: (status) =>
+          (status >= 200 && status < 300) || status === 404,
+      }
     );
+    if (response.status === 404) {
+      return { status: 404, data: null };
+    }
     console.log('getTotalEngagement response', response);
     return response.data;
   } catch (error) {

--- a/libs/shop/data/src/lib/meeting-stors.ts
+++ b/libs/shop/data/src/lib/meeting-stors.ts
@@ -4,6 +4,8 @@ import type { MeetingIceServer } from './hooks/meeting/types';
 interface MeetingState {
   meetingId: string;
   teamId: string;
+  lastEndedMeetingId: string;
+  lastEndedTeamId: string;
   iceServers: MeetingIceServer[];
   isUploading: boolean;
   isRecording: boolean;
@@ -11,6 +13,7 @@ interface MeetingState {
   startTime: string | null;
   setMeetingId: (value: string) => void;
   setTeamId: (value: string) => void;
+  setLastEndedMeeting: (meetingId: string, teamId: string) => void;
   setIceServers: (value: MeetingIceServer[]) => void;
   setIsUploading: (value: boolean) => void;
   setIsRecording: (value: boolean) => void;
@@ -21,6 +24,8 @@ interface MeetingState {
 export const useMeetingStore = create<MeetingState>()((set) => ({
   meetingId: '',
   teamId: '',
+  lastEndedMeetingId: '',
+  lastEndedTeamId: '',
   iceServers: [],
   isUploading: false,
   isRecording: false,
@@ -28,6 +33,8 @@ export const useMeetingStore = create<MeetingState>()((set) => ({
   startTime: null,
   setMeetingId: (value: string) => set({ meetingId: value }),
   setTeamId: (value: string) => set({ teamId: value }),
+  setLastEndedMeeting: (meetingId: string, teamId: string) =>
+    set({ lastEndedMeetingId: meetingId, lastEndedTeamId: teamId }),
   setIceServers: (value: MeetingIceServer[]) => set({ iceServers: value }),
   setIsUploading: (value: boolean) => set({ isUploading: value }),
   setIsRecording: (value: boolean) => set({ isRecording: value }),

--- a/libs/ui/src/lib/components/Header.tsx
+++ b/libs/ui/src/lib/components/Header.tsx
@@ -99,6 +99,7 @@ export function Header() {
   const {
     meetingId,
     teamId: activeMeetingTeamId,
+    setLastEndedMeeting,
     setMeetingId,
     setTeamId,
     setIceServers,
@@ -307,6 +308,12 @@ export function Header() {
   const handleGlobalMeetingEvent = useCallback(
     (event: MeetingEvent) => {
       if (event.type === 'meeting-ended') {
+        if (meetingIdRef.current && activeMeetingTeamIdRef.current) {
+          setLastEndedMeeting(
+            meetingIdRef.current,
+            activeMeetingTeamIdRef.current
+          );
+        }
         setMeeting(false);
         setHasActiveMeeting(false);
         setMeetingId('');
@@ -329,6 +336,7 @@ export function Header() {
       currentTeamId,
       router,
       setHasActiveMeeting,
+      setLastEndedMeeting,
       setMeeting,
       setMeetingId,
       setStartTime,
@@ -409,6 +417,9 @@ export function Header() {
         setLoading(true);
         setLoadingState(MESSAGE_LEAVING_MEETING);
 
+        if (meetingIdRef.current) {
+          setLastEndedMeeting(meetingIdRef.current, currentTeamId);
+        }
         await leaveMeeting(currentTeamId);
 
         setMeeting(false);

--- a/libs/ui/src/lib/components/MiniMeetingOverlay.tsx
+++ b/libs/ui/src/lib/components/MiniMeetingOverlay.tsx
@@ -12,7 +12,13 @@ import NoMike from '../../assets/NoMike.svg';
 import Kamera from '../../assets/Kamera.svg';
 
 export function MiniMeetingOverlay() {
-  const { meetingId, setMeetingId, teamId, setTeamId } = useMeetingStore();
+  const {
+    meetingId,
+    setMeetingId,
+    teamId,
+    setTeamId,
+    setLastEndedMeeting,
+  } = useMeetingStore();
   const { localStream, remoteStreams, isSpeaking, startRecording, stopRecording } = useMeeting();
   const { setMeeting } = useServerJoinedTeam();
   const { setLoading, setLoadingState } = useLoadingStore();
@@ -67,6 +73,9 @@ export function MiniMeetingOverlay() {
 
     try {
       console.log(`[${now}] MiniOverlay: [EXIT] Calling leaveMeeting...`);
+      if (meetingId) {
+        setLastEndedMeeting(meetingId, teamId);
+      }
       await leaveMeeting(teamId);
       setMeeting(false);
       setMeetingId('');

--- a/libs/ui/src/lib/pages/MainRoomPage.tsx
+++ b/libs/ui/src/lib/pages/MainRoomPage.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
-  getIndividualEngagement,
-  getMeetingSummaries,
   getTeamDetail,
   getTotalEngagement,
+  type ParticipantEngagementMetrics,
+  useMeetingStore,
   useServerIdStore,
 } from '@org/shop-data';
 import { useProfile } from '../../context';
@@ -16,6 +16,7 @@ import { ParticipationChart } from '../components/ParticipationChart';
 
 export function MainRoomPage() {
   const { serverId } = useServerIdStore();
+  const { lastEndedMeetingId, lastEndedTeamId } = useMeetingStore();
   const router = useRouter();
   const { profile } = useProfile();
   const [participationRate, setParticipationRate] = useState<number | null>(
@@ -47,56 +48,62 @@ export function MainRoomPage() {
 
   useEffect(() => {
     if (!serverId) return;
-
-    const getLatestMeetingId = async () => {
-      const summaries = await getMeetingSummaries(serverId);
-      if (!Array.isArray(summaries) || summaries.length === 0) {
-        return '';
-      }
-
-      const latestSummary = [...summaries].sort((a: any, b: any) => {
-        const left = new Date(
-          a?.createdAt || a?.startedAt || a?.updatedAt || 0
-        ).getTime();
-        const right = new Date(
-          b?.createdAt || b?.startedAt || b?.updatedAt || 0
-        ).getTime();
-
-        return right - left;
-      })[0];
-
-      return String(latestSummary?.meetingId || '').trim();
-    };
+    if (lastEndedTeamId !== serverId || !lastEndedMeetingId) return;
 
     const fetchParticipation = async () => {
+      const totalEngagement = await getTotalEngagement(
+        serverId,
+        lastEndedMeetingId
+      );
+
+      if (!('participants' in totalEngagement)) {
+        return false;
+      }
+
+      const profileIds = [
+        profile?.userId,
+        profile?.id,
+        profile?.user_id,
+        profile?.accountId,
+      ]
+        .map((value) => String(value ?? '').trim())
+        .filter(Boolean);
+
+      const myMetrics = totalEngagement.participants.find(
+        (participant: ParticipantEngagementMetrics) =>
+          profileIds.includes(String(participant.userId ?? '').trim())
+      );
+
+      setParticipationRate(myMetrics?.participationRate ?? 0);
+      return true;
+    };
+
+    let isCancelled = false;
+    let attempts = 0;
+    const maxAttempts = 20;
+
+    const pollParticipation = async () => {
+      if (isCancelled || attempts >= maxAttempts) return;
+      attempts += 1;
+
       try {
-        const latestMeetingId = await getLatestMeetingId();
-
-        if (!latestMeetingId) {
-          console.warn('No latest meetingId found, skipping participation fetch');
-          return;
-        }
-
-        const totalEngagement = await getTotalEngagement(serverId, latestMeetingId);
-        const fetchedMeetingId = totalEngagement?.meetingId;
-
-        if (!fetchedMeetingId) return;
-
-        const individualEngagement = await getIndividualEngagement(
-          serverId,
-          fetchedMeetingId
-        );
-
-        if (individualEngagement?.currentRate != null) {
-          setParticipationRate(individualEngagement.currentRate);
+        const resolved = await fetchParticipation();
+        if (!resolved && !isCancelled) {
+          window.setTimeout(() => {
+            void pollParticipation();
+          }, 3000);
         }
       } catch (error) {
         console.error('fetchParticipation error', error);
       }
     };
 
-    void fetchParticipation();
-  }, [serverId]);
+    void pollParticipation();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [lastEndedMeetingId, lastEndedTeamId, profile, serverId]);
 
   return (
     <main

--- a/libs/ui/src/lib/pages/layout/MainRoomWrapper.tsx
+++ b/libs/ui/src/lib/pages/layout/MainRoomWrapper.tsx
@@ -52,6 +52,10 @@ export function MainRoomWrapper() {
           currentServerId,
           meetingId
         );
+        if (!('meetingId' in totalEngagement)) {
+          console.log('totalEngagement not ready yet');
+          return;
+        }
         fetchedMeetingId = totalEngagement.meetingId;
         setEngagementMeetingId(fetchedMeetingId);
         console.log(totalEngagement, 'totalEngagement');


### PR DESCRIPTION
## 관련 이슈
- Closes #246

## 작업 내용
- 회의 종료 시 마지막 회의/team 정보를 store에 보존하도록 수정
- 참여도 조회 API의 404 응답을 정상 흐름으로 처리
- 메인 화면에서 마지막 종료 회의 기준으로 참여도 재조회 및 폴링 추가
- 기존 참여도 래퍼에서 미생성 상태 방어 로직 추가

## 검증
- apps/web tsconfig typecheck
- libs/ui tsconfig typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic tracking of the most recently ended meeting and team.
  * Implemented retry logic with polling for engagement metrics retrieval after meetings conclude.

* **Bug Fixes**
  * Enhanced handling of meeting engagement data availability with readiness checks to prevent premature metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->