### PR TITLE
fix: 원격 영상 좌우반전 렌더링 수정

### DIFF
--- a/libs/ui/src/lib/pages/MeetingRoomPage.tsx
+++ b/libs/ui/src/lib/pages/MeetingRoomPage.tsx
@@ -337,6 +337,7 @@ export const MeetingRoomPage = () => {
       id: myId,
       name: `${profile?.name || '나'} (나)`,
       isLocal: true,
+      mirrorVideo: true,
       stream: localStream,
       isSpeaking,
       isMike,
@@ -354,6 +355,7 @@ export const MeetingRoomPage = () => {
         id: participantId || participant.name,
         name: participant.name || '참가자',
         isLocal: false,
+        mirrorVideo: false,
         stream: remoteStream?.stream,
         isSpeaking: !!remoteVoices[String(participantId)],
         isMike: true,
@@ -459,12 +461,15 @@ export const MeetingRoomPage = () => {
         >
           {allParticipants.map((participant, index) => (
             <div
-              key={String(participant.id)}
+              key={`${participant.isLocal ? 'local' : 'remote'}:${String(
+                participant.id || participant.name
+              )}`}
               className={`min-h-0 ${getCardWrapperClassName(index)}`}
             >
               <VideoCard
                 name={participant.name}
                 isLocal={participant.isLocal}
+                mirrorVideo={participant.mirrorVideo}
                 isSpeaking={participant.isSpeaking}
                 isMike={participant.isMike}
                 isKamera={participant.isKamera}

--- a/libs/ui/src/lib/pages/VideoCard.tsx
+++ b/libs/ui/src/lib/pages/VideoCard.tsx
@@ -8,6 +8,7 @@ import WebRTC from './WebRTC';
 type VideoCardProps = {
   name: string;
   isLocal?: boolean;
+  mirrorVideo?: boolean;
   isSpeaking?: boolean;
   isMike: boolean;
   isKamera: boolean;
@@ -19,6 +20,7 @@ type VideoCardProps = {
 export const VideoCard = ({
   name,
   isLocal = false,
+  mirrorVideo = false,
   isSpeaking,
   isMike,
   isKamera,
@@ -53,6 +55,7 @@ export const VideoCard = ({
             key={`${isLocal ? 'local' : 'remote'}:${name}:${streamSignature}`}
             stream={videoStream}
             isLocal={isLocal}
+            mirror={mirrorVideo}
           />
         </div>
       )}

--- a/libs/ui/src/lib/pages/WebRTC.tsx
+++ b/libs/ui/src/lib/pages/WebRTC.tsx
@@ -5,9 +5,14 @@ import { useEffect, useMemo, useRef } from 'react';
 interface WebRTCProps {
   stream: MediaStream | null;
   isLocal?: boolean;
+  mirror?: boolean;
 }
 
-export default function WebRTC({ stream, isLocal }: WebRTCProps) {
+export default function WebRTC({
+  stream,
+  isLocal,
+  mirror = false,
+}: WebRTCProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -95,7 +100,7 @@ export default function WebRTC({ stream, isLocal }: WebRTCProps) {
         muted
         playsInline
         style={{
-          transform: isLocal ? 'scaleX(-1)' : 'none',
+          transform: mirror ? 'scaleX(-1)' : 'none',
           objectFit: 'contain',
         }}
         className="w-full h-full bg-black"


### PR DESCRIPTION
## 관련 이슈
- Closes #247

## 작업 내용
- 비디오 미러링 여부를 로컬 여부와 분리해 명시적으로 전달하도록 수정
- 셀프뷰에만 좌우반전이 적용되고 원격 영상에는 적용되지 않도록 보정
- 참가자 카드 key에 로컬/원격 역할을 포함해 잘못된 DOM 재사용 가능성 방지

## 검증
- apps/web tsconfig typecheck
- libs/ui tsconfig typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant video display with proper mirroring control, ensuring correct orientation for both local and remote video feeds across the meeting interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->