### PR TITLE
Closes #249 [FE] 회의 녹음 재시작 시 초시계 초기화 문제

### DIFF
--- a/libs/shop/data/src/lib/hooks/meeting/use-send-meeting-signal.ts
+++ b/libs/shop/data/src/lib/hooks/meeting/use-send-meeting-signal.ts
@@ -19,6 +19,7 @@ export interface MeetingSignal {
   sdpMid?: string;
   sdpMLineIndex?: number;
   startedAt?: string;
+  elapsedMs?: number;
 }
 
 export function useMeetingSignal(

--- a/libs/shop/data/src/lib/meeting-stors.ts
+++ b/libs/shop/data/src/lib/meeting-stors.ts
@@ -11,6 +11,7 @@ interface MeetingState {
   isRecording: boolean;
   hasActiveMeeting: boolean;
   startTime: string | null;
+  recordingElapsedMs: number;
   setMeetingId: (value: string) => void;
   setTeamId: (value: string) => void;
   setLastEndedMeeting: (meetingId: string, teamId: string) => void;
@@ -19,6 +20,7 @@ interface MeetingState {
   setIsRecording: (value: boolean) => void;
   setHasActiveMeeting: (value: boolean) => void;
   setStartTime: (value: string | null) => void;
+  setRecordingElapsedMs: (value: number) => void;
 }
 
 export const useMeetingStore = create<MeetingState>()((set) => ({
@@ -31,6 +33,7 @@ export const useMeetingStore = create<MeetingState>()((set) => ({
   isRecording: false,
   hasActiveMeeting: false,
   startTime: null,
+  recordingElapsedMs: 0,
   setMeetingId: (value: string) => set({ meetingId: value }),
   setTeamId: (value: string) => set({ teamId: value }),
   setLastEndedMeeting: (meetingId: string, teamId: string) =>
@@ -40,4 +43,5 @@ export const useMeetingStore = create<MeetingState>()((set) => ({
   setIsRecording: (value: boolean) => set({ isRecording: value }),
   setHasActiveMeeting: (value: boolean) => set({ hasActiveMeeting: value }),
   setStartTime: (value: string | null) => set({ startTime: value }),
+  setRecordingElapsedMs: (value: number) => set({ recordingElapsedMs: value }),
 }));

--- a/libs/ui/src/hooks/useMeetingWebRTC.ts
+++ b/libs/ui/src/hooks/useMeetingWebRTC.ts
@@ -101,6 +101,8 @@ export function useMeetingWebRTC(
     isRecording,
     setIsRecording,
     setStartTime,
+    recordingElapsedMs,
+    setRecordingElapsedMs,
   } = useMeetingStore();
   const iceServers = useRef<RTCIceServer[]>(normalizeIceServers(meetingIceServers));
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
@@ -334,12 +336,13 @@ export function useMeetingWebRTC(
     setLocalStream(null);
     setIsRecording(false);
     setStartTime(null);
+    setRecordingElapsedMs(0);
     recordingStartedAtRef.current = null;
     recordingMimeTypeRef.current = '';
     mediaRecorderRef.current = null;
     recordedChunksRef.current = [];
     cleanupRecordingMix();
-  }, [cleanupRecordingMix, setIsRecording, setStartTime]);
+  }, [cleanupRecordingMix, setIsRecording, setRecordingElapsedMs, setStartTime]);
 
   const getMeetingParticipantIds = useCallback(async () => {
     const activeMeeting = await getActiveMeetings(teamIdRef.current);
@@ -354,7 +357,11 @@ export function useMeetingWebRTC(
   }, []);
 
   const broadcastRecordingState = useCallback(
-    async (type: 'recording-started' | 'recording-stopped', startedAt?: string) => {
+    async (
+      type: 'recording-started' | 'recording-stopped',
+      startedAt?: string,
+      elapsedMs?: number
+    ) => {
       try {
         const participantIds = await getMeetingParticipantIds();
         participantIds.forEach((participantId: string) => {
@@ -363,6 +370,7 @@ export function useMeetingWebRTC(
             fromUserId: myId,
             toUserId: participantId,
             startedAt,
+            elapsedMs,
           });
         });
       } catch (error) {
@@ -558,11 +566,13 @@ export function useMeetingWebRTC(
         recordingStartedAtRef.current = signal.startedAt || new Date().toISOString();
         setIsRecording(true);
         setStartTime(recordingStartedAtRef.current);
+        setRecordingElapsedMs(Math.max(0, signal.elapsedMs ?? 0));
         return;
       } else if (type === 'recording-stopped') {
         recordingStartedAtRef.current = null;
         setIsRecording(false);
         setStartTime(null);
+        setRecordingElapsedMs(Math.max(0, signal.elapsedMs ?? 0));
         return;
       } else if (type === 'offer') {
         try {
@@ -744,11 +754,15 @@ export function useMeetingWebRTC(
 
     const startedAt = recordingStartedAtRef.current || new Date().toISOString();
     const intervalId = setInterval(() => {
-      void broadcastRecordingState('recording-started', startedAt);
+      void broadcastRecordingState(
+        'recording-started',
+        startedAt,
+        recordingElapsedMs
+      );
     }, 3000);
 
     return () => clearInterval(intervalId);
-  }, [broadcastRecordingState, isRecording, meetingId, teamId]);
+  }, [broadcastRecordingState, isRecording, meetingId, recordingElapsedMs, teamId]);
 
   useEffect(() => {
     if (!isRecording || !recordingDestinationRef.current) {
@@ -927,7 +941,11 @@ export function useMeetingWebRTC(
       recorder.start(1000);
       setIsRecording(true);
       setStartTime(startedAt);
-      void broadcastRecordingState('recording-started', startedAt);
+      void broadcastRecordingState(
+        'recording-started',
+        startedAt,
+        recordingElapsedMs
+      );
       log('MediaRecorder SUCCESS. state:', recorder.state);
       log('MIME Type selected:', recorder.mimeType || mimeType);
     };
@@ -970,20 +988,36 @@ export function useMeetingWebRTC(
     cleanupRecordingMix,
     ensureMixedRecordingStream,
     log,
+    recordingElapsedMs,
     setIsRecording,
+    setRecordingElapsedMs,
     setStartTime,
   ]);
 
   const stopRecording = useCallback(() => {
     log('stopRecording triggered manually');
+    const startedAt = recordingStartedAtRef.current;
+    const nextElapsedMs =
+      startedAt != null
+        ? recordingElapsedMs +
+          Math.max(0, Date.now() - new Date(startedAt).getTime())
+        : recordingElapsedMs;
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
       mediaRecorderRef.current.stop();
     }
     setIsRecording(false);
     setStartTime(null);
+    setRecordingElapsedMs(nextElapsedMs);
     recordingStartedAtRef.current = null;
-    void broadcastRecordingState('recording-stopped');
-  }, [broadcastRecordingState, log, setIsRecording, setStartTime]);
+    void broadcastRecordingState('recording-stopped', undefined, nextElapsedMs);
+  }, [
+    broadcastRecordingState,
+    log,
+    recordingElapsedMs,
+    setIsRecording,
+    setRecordingElapsedMs,
+    setStartTime,
+  ]);
 
   const initLocalMedia = useCallback(async () => {
     log('initLocalMedia starting...');

--- a/libs/ui/src/lib/components/ReceiveAiAssistant.tsx
+++ b/libs/ui/src/lib/components/ReceiveAiAssistant.tsx
@@ -14,7 +14,7 @@ export const ReceiveAiAssistant = () => {
   const { serverId } = useServerIdStore();
   const { meeting } = useServerJoinedTeam();
   const { isRecording, startRecording, stopRecording } = useMeeting();
-  const { startTime, hasActiveMeeting } = useMeetingStore();
+  const { startTime, hasActiveMeeting, recordingElapsedMs } = useMeetingStore();
   const { profile } = useProfile();
   const { teamMembers } = useServerState();
 
@@ -52,20 +52,23 @@ export const ReceiveAiAssistant = () => {
     }
 
     const updateTimer = () => {
-      let startValue = startTime;
-      if (
-        typeof startValue === 'string' &&
-        !startValue.includes('T') &&
-        startValue.includes(' ')
-      ) {
-        startValue = startValue.replace(' ', 'T');
+      let diff = Math.max(0, recordingElapsedMs);
+      if (startTime) {
+        let startValue = startTime;
+        if (
+          typeof startValue === 'string' &&
+          !startValue.includes('T') &&
+          startValue.includes(' ')
+        ) {
+          startValue = startValue.replace(' ', 'T');
+        }
+
+        const start = new Date(startValue).getTime();
+        if (!Number.isNaN(start)) {
+          diff += Math.max(0, Date.now() - start);
+        }
       }
 
-      const start = new Date(startValue).getTime();
-      if (Number.isNaN(start)) return;
-
-      const now = Date.now();
-      const diff = Math.max(0, now - start);
       const hours = Math.floor(diff / 3600000);
       const minutes = Math.floor((diff % 3600000) / 60000);
       const seconds = Math.floor((diff % 60000) / 1000);
@@ -82,7 +85,7 @@ export const ReceiveAiAssistant = () => {
     updateTimer();
     const intervalId = setInterval(updateTimer, 1000);
     return () => clearInterval(intervalId);
-  }, [hasActiveMeeting, meeting, startTime]);
+  }, [hasActiveMeeting, meeting, recordingElapsedMs, startTime]);
 
   const isSummary = pathname?.includes('/summary');
   const isFeedback = pathname?.includes('/feedback');


### PR DESCRIPTION
## 작업 내용
- 녹음 누적 시간을 store에 보존하도록 추가
- 녹음 시작/중지 시 누적 시간을 기준으로 초시계가 이어지도록 수정
- recording signal에 누적 시간을 포함해 원격 참가자도 동일한 타이머를 보도록 수정
- 녹음 중지 상태에서는 마지막 누적 시간이 유지되도록 타이머 UI 보정

## 검증
- apps/web tsconfig typecheck
- libs/ui tsconfig typecheck